### PR TITLE
Rake cassandra connection timeout

### DIFF
--- a/lib/cassandra_datum/tasks.rb
+++ b/lib/cassandra_datum/tasks.rb
@@ -38,7 +38,7 @@ namespace :cassandra do
 
   desc "Create the keyspace in Cassandra as defined in config/cassandra.yml"
   task :create do
-    client = Cassandra.new "system", ["#{`hostname`.strip}:9160"]. { :connect_timeout => 1 }
+    client = Cassandra.new "system", ["#{`hostname`.strip}:9160"], { :connect_timeout => 1 }
 
     begin
       puts "Creating keyspace #{keyspace_name}..."


### PR DESCRIPTION
This fixes an issue we're seeing on Jenkins where timeout exceptions in the cassandra client are sometimes preventing keyspace creation.

I wanted to see if adding the timeout here is ok.  It might make sense to have the individual services pass in the timeout option rather than hardcode the value.
