### PR TITLE
Only set the type if it is not provided.

### DIFF
--- a/lib/cassandra_datum/base.rb
+++ b/lib/cassandra_datum/base.rb
@@ -267,7 +267,7 @@ class Base
   end
 
   def populate_type_if_exists
-    self.type = self.class.name if self.respond_to?(:type=)
+    self.type = self.class.name if self.respond_to?(:type=) && self.type.blank?
   end
 
   def self.initialize_datum(res)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -44,6 +44,18 @@ class BaseTest < Test::Unit::TestCase
     assert_equal datum.class.to_s, datum.type
   end
 
+  should "not populate type field if type provided" do
+    datum = FactoryGirl.create(:polymorphic_cassandra_datum)
+    assert_equal datum.class.to_s, datum.type
+    
+    new_type = "DatumWithArrayAndHash"
+    
+    datum.type = new_type
+    datum.save!
+    
+    assert_equal new_type, datum.type
+  end
+  
   context 'save' do
     should 'save attributes to cassandra' do
       datum = FactoryGirl.create(:cassandra_datum)


### PR DESCRIPTION
This is needed for the high watermark migration. I need to convert BackupRun to GoogleMailBackupRun in order to get the low_watermark attributes. This allows me to update the type attribute without it being replaced by the class name.
