### PR TITLE
Changes Necessary to Switch from Thrift to CQL 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "twitter_cassandra", :git => "https://github.com/backupify/twitter_cassandra.git", :require => "cassandra/1.2"
 gem "active_attr", :git => "http://github.com/backupify/active_attr.git"
 
 group :development do

--- a/cassandra_datum.gemspec
+++ b/cassandra_datum.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency(%q<activesupport>, [">= 2.3.5"])
   gem.add_runtime_dependency(%q<activemodel>, [">= 2.3.5"])
   gem.add_runtime_dependency(%q<activerecord>, [">= 2.3.5"])
-  gem.add_runtime_dependency(%q<twitter_cassandra>, [">= 0"])
   gem.add_runtime_dependency(%q<active_attr>, [">= 0"])
   gem.add_runtime_dependency(%q<exception_helper>, [">= 0"])
 end

--- a/lib/cassandra_datum/base.rb
+++ b/lib/cassandra_datum/base.rb
@@ -39,7 +39,7 @@ class Base
   def initialize_with_utf8_encoding(*attr)
     if attr.size > 0 && attr.first.is_a?(Hash)
       #careful not to trounce timestamps in TwitterCassandra::OrderedHash
-      timestamps = attr.first.is_a?(TwitterCassandra::OrderedHash) ? attr.first.timestamps : nil
+      timestamps = attr.first.respond_to?(:timestamps) ? attr.first.timestamps : nil
       attr.first.each { |k, v| attr.first[k] = encode_value(v) unless v.blank? }
       attr.first.instance_variable_set(:@timestamps, timestamps) if timestamps.present?
     end

--- a/lib/cassandra_datum/base.rb
+++ b/lib/cassandra_datum/base.rb
@@ -2,7 +2,6 @@ require 'active_attr/model'
 require 'active_model/callbacks'
 require 'active_record/errors'
 require 'active_record/validations'
-require 'twitter_cassandra'
 require 'cassandra_datum/cassandra_retry'
 
 module CassandraDatum

--- a/lib/cassandra_datum/cassandra_retry.rb
+++ b/lib/cassandra_datum/cassandra_retry.rb
@@ -2,8 +2,8 @@ require 'exception_helper/retry'
 
 module CassandraDatum
   module Exceptions
-    unless Object.const_defined?('::Thrift::Exception')
-      class ::Thrift::Exception < StandardError
+    unless Object.const_defined?('::Cassandra::Error')
+      class Cassandra::Error < StandardError
         def initialize(message)
           super
           @message = message
@@ -34,20 +34,24 @@ module CassandraDatum
     # end
 
     unless Object.const_defined?('::ThriftClient::NoServersAvailable')
-      class ::ThriftClient::NoServersAvailable < Thrift::Exception
+      class ::ThriftClient::NoServersAvailable < Cassandra::Error
       end
     end
 
     unless Object.const_defined?('::CassandraThrift::TimedOutException')
-      class ::CassandraThrift::TimedOutException < Thrift::Exception
+      class ::CassandraThrift::TimedOutException < Cassandra::Error
       end
     end
   end
 
   module CassandraRetry
     CASSANDRA_EXCEPTIONS = [
-      ::Thrift::Exception,
-      ::ThriftClient::NoServersAvailable,
+        ::Cassandra::Errors::NoHostsAvailable,
+        ::Cassandra::Errors::UnavailableError,
+        ::Cassandra::Errors::TimeoutError,
+        ::Cassandra::Errors::ReadTimeoutError,
+        ::Cassandra::Errors::WriteTimeoutError,
+        ::Cassandra::Error, ThreadError,
     ].freeze
 
     class << self

--- a/lib/cassandra_datum/cassandra_retry.rb
+++ b/lib/cassandra_datum/cassandra_retry.rb
@@ -1,6 +1,49 @@
 require 'exception_helper/retry'
 
 module CassandraDatum
+  module Exceptions
+    unless Object.const_defined?('::Thrift::Exception')
+      class ::Thrift::Exception < StandardError
+        def initialize(message)
+          super
+          @message = message
+        end
+
+        attr_reader :message
+      end
+    end
+
+    # This code is left here for documentation sake. We used to get TransportException
+    # from Thrift, but there is no equivalent with our CQL driver.
+    ##################################
+    # unless Object.const_defined?('Thrift::TransportException')
+    #   class Thrift::TransportException < Thrift::Exception
+    #     UNKNOWN = 0
+    #     NOT_OPEN = 1
+    #     ALREADY_OPEN = 2
+    #     TIMED_OUT = 3
+    #     END_OF_FILE = 4
+
+    #     attr_reader :type
+
+    #     def initialize(type = UNKNOWN, message = nil)
+    #       super(message)
+    #       @type = type
+    #     end
+    #   end
+    # end
+
+    unless Object.const_defined?('::ThriftClient::NoServersAvailable')
+      class ::ThriftClient::NoServersAvailable < Thrift::Exception
+      end
+    end
+
+    unless Object.const_defined?('::CassandraThrift::TimedOutException')
+      class ::CassandraThrift::TimedOutException < Thrift::Exception
+      end
+    end
+  end
+
   module CassandraRetry
     CASSANDRA_EXCEPTIONS = [
       ::Thrift::Exception,

--- a/lib/cassandra_datum/cassandra_retry.rb
+++ b/lib/cassandra_datum/cassandra_retry.rb
@@ -12,36 +12,6 @@ module CassandraDatum
         attr_reader :message
       end
     end
-
-    # This code is left here for documentation sake. We used to get TransportException
-    # from Thrift, but there is no equivalent with our CQL driver.
-    ##################################
-    # unless Object.const_defined?('Thrift::TransportException')
-    #   class Thrift::TransportException < Thrift::Exception
-    #     UNKNOWN = 0
-    #     NOT_OPEN = 1
-    #     ALREADY_OPEN = 2
-    #     TIMED_OUT = 3
-    #     END_OF_FILE = 4
-
-    #     attr_reader :type
-
-    #     def initialize(type = UNKNOWN, message = nil)
-    #       super(message)
-    #       @type = type
-    #     end
-    #   end
-    # end
-
-    unless Object.const_defined?('::ThriftClient::NoServersAvailable')
-      class ::ThriftClient::NoServersAvailable < Cassandra::Error
-      end
-    end
-
-    unless Object.const_defined?('::CassandraThrift::TimedOutException')
-      class ::CassandraThrift::TimedOutException < Cassandra::Error
-      end
-    end
   end
 
   module CassandraRetry

--- a/lib/cassandra_datum/tasks.rb
+++ b/lib/cassandra_datum/tasks.rb
@@ -6,8 +6,8 @@ namespace :cassandra do
   task :reset do
     begin
       Rake::Task['cassandra:drop'].invoke
-    rescue Thrift::Exception => e
-      puts "ignoring thrift exception #{e} (keyspace probably doesn't exist)"
+    rescue ::Cassandra::Error => e
+      puts "ignoring cassandra exception #{e} (keyspace probably doesn't exist)"
     end
 
     Rake::Task['cassandra:create'].invoke
@@ -25,9 +25,9 @@ namespace :cassandra do
         client.drop_keyspace keyspace_name
       end
 
-    rescue Thrift::Exception => e
+    rescue ::Cassandra::Error => e
       if ENV['IGNORE_THRIFT_EXCEPTIONS']
-        puts "ignoring thrift exception #{e}"
+        puts "ignoring cassandra exception #{e}"
       else
         raise e
       end
@@ -54,9 +54,9 @@ namespace :cassandra do
         client.add_keyspace keyspace_definition
       end
 
-    rescue Thrift::Exception => e
+    rescue ::Cassandra::Error => e
       if ENV['IGNORE_THRIFT_EXCEPTIONS']
-        puts "ignoring thrift exception #{e}"
+        puts "ignoring cassandra exception #{e}"
       else
         raise e
       end
@@ -100,9 +100,9 @@ namespace :cassandra do
 
       end
 
-    rescue Thrift::Exception => e
+    rescue ::Cassandra::Error => e
       if ENV['IGNORE_THRIFT_EXCEPTIONS']
-        puts "ignoring thrift exception #{e}"
+        puts "ignoring cassandra exception #{e}"
       else
         raise e
       end


### PR DESCRIPTION
We are moving away from using TwitterCassandra, so all checks referring directly to the TwitterCassandra class should be replaced with a more generic check.